### PR TITLE
Add namespace to fix stylelint deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Example:
     "stylelint-selector-qualifying-element"
   ],
   "rules": {
-    "selector-qualifying-element": {
+    "plugin/selector-qualifying-element": {
       "noElementWithClass": true // Or false
       "noElementWithId": true // Or false
       "noElementWithAttribute": false // Or true

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const assign = require('object-assign');
 const stylelint = require('stylelint');
-const ruleName = 'selector-qualifying-element';
+const ruleName = 'plugin/selector-qualifying-element';
 const messages = stylelint.utils.ruleMessages(ruleName, {});
 
 const arrayContains = (searchItem, array) =>


### PR DESCRIPTION
Fixes deprecation warning: ‼ Plugin rules that aren't namespaced have been deprecated, and in 7.0 they wl be disallowed. [stylelint]
